### PR TITLE
Optional Provide Assembly

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -103,13 +103,12 @@ namespace AutoUpdaterDotNET
             Start(AppCastURL);
         }
 
-
         /// <summary>
         ///     Start checking for new version of application and display dialog to the user if update is available.
         /// </summary>
         /// <param name="appCast">URL of the xml file that contains information about latest version of the application.</param>
-        /// <param name="assy">Assembyl to use for version checking</param>
-        public static void Start(String appCast, Assembly assy=null)
+        /// <param name="myAssembly">Assembly to use for version checking.</param>
+        public static void Start(String appCast, Assembly myAssembly = null)
         {
             AppCastURL = appCast;
 
@@ -119,7 +118,7 @@ namespace AutoUpdaterDotNET
 
             backgroundWorker.DoWork += BackgroundWorkerDoWork;
 
-            backgroundWorker.RunWorkerAsync(assy ?? Assembly.GetEntryAssembly());
+            backgroundWorker.RunWorkerAsync(myAssembly ?? Assembly.GetEntryAssembly());
         }
 
         private static void BackgroundWorkerDoWork(object sender, DoWorkEventArgs e)

--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -119,7 +119,7 @@ namespace AutoUpdaterDotNET
 
             backgroundWorker.DoWork += BackgroundWorkerDoWork;
 
-            backgroundWorker.RunWorkerAsync(assy==null? System.Reflection.Assembly.GetEntryAssembly(): assy);
+            backgroundWorker.RunWorkerAsync(assy ?? Assembly.GetEntryAssembly());
         }
 
         private static void BackgroundWorkerDoWork(object sender, DoWorkEventArgs e)

--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
@@ -103,11 +103,13 @@ namespace AutoUpdaterDotNET
             Start(AppCastURL);
         }
 
+
         /// <summary>
         ///     Start checking for new version of application and display dialog to the user if update is available.
         /// </summary>
         /// <param name="appCast">URL of the xml file that contains information about latest version of the application.</param>
-        public static void Start(String appCast)
+        /// <param name="assy">Assembyl to use for versino checking</param>
+        public static void Start(String appCast, Assembly assy=null)
         {
             AppCastURL = appCast;
 
@@ -117,12 +119,12 @@ namespace AutoUpdaterDotNET
 
             backgroundWorker.DoWork += BackgroundWorkerDoWork;
 
-            backgroundWorker.RunWorkerAsync();
+            backgroundWorker.RunWorkerAsync(assy==null? System.Reflection.Assembly.GetEntryAssembly(): assy);
         }
 
         private static void BackgroundWorkerDoWork(object sender, DoWorkEventArgs e)
         {
-            Assembly mainAssembly = Assembly.GetEntryAssembly();
+            Assembly mainAssembly = e.Argument as Assembly;
             var companyAttribute =
                 (AssemblyCompanyAttribute) GetAttribute(mainAssembly, typeof (AssemblyCompanyAttribute));
             var titleAttribute = (AssemblyTitleAttribute) GetAttribute(mainAssembly, typeof (AssemblyTitleAttribute));

--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -108,7 +108,7 @@ namespace AutoUpdaterDotNET
         ///     Start checking for new version of application and display dialog to the user if update is available.
         /// </summary>
         /// <param name="appCast">URL of the xml file that contains information about latest version of the application.</param>
-        /// <param name="assy">Assembyl to use for versino checking</param>
+        /// <param name="assy">Assembyl to use for version checking</param>
         public static void Start(String appCast, Assembly assy=null)
         {
             AppCastURL = appCast;


### PR DESCRIPTION
Added an optional parameter to Start method, this allows you to pass in the Assembly you'd like to use for version checking. The original was failing when the assembly that needed to be checked was called from a main.exe via a dynamic plug in.
Specifically a Microsoft Office VSTO plug in that I wanted to auto update, when using the original code the GetEntryAssembly() call failed and returned null.