### PR TITLE
Implemented ShowSkipButton static property in AutoUpdater to set the visibility of the skip button.

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -69,6 +69,11 @@ namespace AutoUpdaterDotNET
         public static CultureInfo CurrentCulture;
 
         /// <summary>
+        ///     If this is true users can see the skip button.
+        /// </summary>
+        public static Boolean ShowSkipButton = true;
+
+        /// <summary>
         ///     If this is true users see dialog where they can set remind later interval otherwise it will take the interval from
         ///     RemindLaterAt and RemindLaterTimeSpan fields.
         /// </summary>

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -48,6 +48,8 @@ namespace AutoUpdaterDotNET
 
         private void UpdateFormLoad(object sender, EventArgs e)
         {
+            buttonSkip.Visible = AutoUpdater.ShowSkipButton;
+
             if (HideReleaseNotes == false)
             {
                 webBrowser.Navigate(AutoUpdater.ChangeLogURL);


### PR DESCRIPTION
The ShowSkipButton property of AutoUpdater class can set the visibility of the skip button in the UpdateForm.  It is useful in cases where the new version cannot be skipped forever, but it can just be delayed.