### PR TITLE
Fix UseLatestIE and OnDownloadComplete to get EXE name from Process.GetCurrentProcess()

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -76,7 +76,7 @@ namespace AutoUpdaterDotNET
                 {
                     UseShellExecute = true,
                     FileName = installerPath,
-                    Arguments = $"\"{_tempPath}\" \"{Assembly.GetEntryAssembly().Location}\""
+                    Arguments = $"\"{_tempPath}\" \"{Process.GetCurrentProcess().MainModule.FileName}\""
                 };
             }
             try

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -77,7 +77,7 @@ namespace AutoUpdaterDotNET
                     Registry.CurrentUser.OpenSubKey(
                         @"SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION", true))
                 {
-                    registryKey?.SetValue(Path.GetFileName(Assembly.GetEntryAssembly().Location), ieValue,
+                    registryKey?.SetValue(Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName), ieValue,
                         RegistryValueKind.DWord);
                 }
             }


### PR DESCRIPTION
Fixes #51 

UseLatestIE and OnDownloadComplete ZIP extraction will now get EXE name from Process.GetCurrentProcess() instead of Assembly.GetEntryAssembly() which is NULL when AutoUpdater.NET is run from an unmanaged application.