### PR TITLE
Fixed localized 'Release' typos in UpdateForm

### DIFF
--- a/AutoUpdater.NET/UpdateForm.da.resx
+++ b/AutoUpdater.NET/UpdateForm.da.resx
@@ -133,7 +133,7 @@
     <value>{0} {1} er nu klar. Du har version {2} installeret. Ønsker du at installere nu?</value>
   </data>
   <data name="labelReleaseNotes.Text" xml:space="preserve">
-    <value>Releae Bemærkninger:</value>
+    <value>Release Bemærkninger:</value>
   </data>
   <data name="labelUpdate.Text" xml:space="preserve">
     <value>En ny version af {0} er klar til download!</value>

--- a/AutoUpdater.NET/UpdateForm.nl.resx
+++ b/AutoUpdater.NET/UpdateForm.nl.resx
@@ -136,6 +136,6 @@
     <value>{0} {1} is beschikbaar!</value>
   </data>
   <data name="labelReleaseNotes.Text" xml:space="preserve">
-    <value>Releae Opmerkingen:</value>
+    <value>Release Opmerkingen:</value>
   </data>
 </root>

--- a/AutoUpdater.NET/UpdateForm.pl.resx
+++ b/AutoUpdater.NET/UpdateForm.pl.resx
@@ -136,6 +136,6 @@
     <value>{0} {1} jest dostępna!</value>
   </data>
   <data name="labelReleaseNotes.Text" xml:space="preserve">
-    <value>Releae Uwagi:</value>
+    <value>Release Uwagi:</value>
   </data>
 </root>

--- a/AutoUpdater.NET/UpdateForm.sv.resx
+++ b/AutoUpdater.NET/UpdateForm.sv.resx
@@ -136,6 +136,6 @@
     <value>{0} {1} är tillgänglig!</value>
   </data>
   <data name="labelReleaseNotes.Text" xml:space="preserve">
-    <value>Releae Anmärkningar:</value>
+    <value>Release Anmärkningar:</value>
   </data>
 </root>


### PR DESCRIPTION
Some more "Releae" typos exist in localization files