### PR TITLE
Fix UAC for non-zip updates

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -125,11 +125,12 @@ namespace AutoUpdaterDotNET
                     FileName = installerPath,
                     UseShellExecute = true,
                     Arguments = $"\"{tempPath}\" \"{Process.GetCurrentProcess().MainModule.FileName}\""
-                };
-                if (AutoUpdater.RunUpdateAsAdmin)
-                {
-                    processStartInfo.Verb = "runas";
-                }
+                };          
+            }
+            
+            if (AutoUpdater.RunUpdateAsAdmin)
+            {
+                processStartInfo.Verb = "runas";
             }
 
             try


### PR DESCRIPTION
Currently, if an update is a non-zip file, it will never be run as an admin, even if **RunUpdateAsAdmin** is set to **true**.