### PR TITLE
fix - using args with .msi

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -176,6 +176,11 @@ namespace AutoUpdaterDotNET
                     FileName = "msiexec",
                     Arguments = $"/i \"{tempPath}\""
                 };
+                if (!string.IsNullOrEmpty(AutoUpdater.InstallerArgs))
+                {
+                    var args = AutoUpdater.InstallerArgs.Split(' ');
+                    processStartInfo.Arguments += " " + string.Join(" ", args);
+                }
             }
 
             if (AutoUpdater.RunUpdateAsAdmin)


### PR DESCRIPTION
Fixed an opportunity to use custom args from config with .msi installer