### PR TITLE
Added the ability to specify the size of the default update form

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -198,10 +198,10 @@ namespace AutoUpdaterDotNET
         /// </summary>
         public static event ParseUpdateInfoHandler ParseUpdateInfoEvent;
 
-		/// <summary>
-		///     Set if you want the default update form to have a different size.
-		/// </summary>
-		public static Size? UpdateFormSize = null;
+        /// <summary>
+        ///     Set if you want the default update form to have a different size.
+        /// </summary>
+        public static Size? UpdateFormSize = null;
 
         /// <summary>
         ///     Start checking for new version of application and display dialog to the user if update is available.
@@ -329,9 +329,11 @@ namespace AutoUpdaterDotNET
         public static void ShowUpdateForm()
         {
             var updateForm = new UpdateForm();
-			if (UpdateFormSize.HasValue) {
-				updateForm.Size = UpdateFormSize.Value;
-			}
+            if (UpdateFormSize.HasValue)
+            {
+                updateForm.Size = UpdateFormSize.Value;
+            }
+
             if (updateForm.ShowDialog().Equals(DialogResult.OK))
             {
                 Exit();

--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -197,6 +198,11 @@ namespace AutoUpdaterDotNET
         /// </summary>
         public static event ParseUpdateInfoHandler ParseUpdateInfoEvent;
 
+		/// <summary>
+		///     Set if you want the default update form to have a different size.
+		/// </summary>
+		public static Size? UpdateFormSize = null;
+
         /// <summary>
         ///     Start checking for new version of application and display dialog to the user if update is available.
         /// </summary>
@@ -323,6 +329,9 @@ namespace AutoUpdaterDotNET
         public static void ShowUpdateForm()
         {
             var updateForm = new UpdateForm();
+			if (UpdateFormSize.HasValue) {
+				updateForm.Size = UpdateFormSize.Value;
+			}
             if (updateForm.ShowDialog().Equals(DialogResult.OK))
             {
                 Exit();

--- a/AutoUpdater.NET/UpdateForm.Designer.cs
+++ b/AutoUpdater.NET/UpdateForm.Designer.cs
@@ -88,8 +88,8 @@ namespace AutoUpdaterDotNET
             // 
             // buttonSkip
             // 
-            this.buttonSkip.DialogResult = System.Windows.Forms.DialogResult.Abort;
             resources.ApplyResources(this.buttonSkip, "buttonSkip");
+            this.buttonSkip.DialogResult = System.Windows.Forms.DialogResult.Abort;
             this.buttonSkip.Image = global::AutoUpdaterDotNET.Properties.Resources.hand_point;
             this.buttonSkip.Name = "buttonSkip";
             this.buttonSkip.UseVisualStyleBackColor = true;

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -34,12 +34,7 @@ namespace AutoUpdaterDotNET
                 webBrowser.Hide();
 
                 Height -= reduceHeight;
-
-                buttonSkip.Location = new Point(buttonSkip.Location.X, buttonSkip.Location.Y - reduceHeight);
-                buttonRemindLater.Location = new Point(buttonRemindLater.Location.X,
-                    buttonRemindLater.Location.Y - reduceHeight);
-                buttonUpdate.Location = new Point(buttonUpdate.Location.X, buttonUpdate.Location.Y - reduceHeight);
-            }
+			}
 
             if (AutoUpdater.Mandatory && AutoUpdater.UpdateMode == Mode.Forced)
             {

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -78,14 +78,15 @@ namespace AutoUpdaterDotNET
                 var reduceHeight = labelReleaseNotes.Height + webBrowser.Height;
                 labelReleaseNotes.Hide();
                 webBrowser.Hide();
-                var labelSize = new Size(Width - 110, 0);
-                labelDescription.MaximumSize = labelUpdate.MaximumSize = labelSize;
                 Height -= reduceHeight;
             }
             else
             {
                 webBrowser.Navigate(AutoUpdater.ChangelogURL);
             }
+
+            var labelSize = new Size(Width - 110, 0);
+            labelDescription.MaximumSize = labelUpdate.MaximumSize = labelSize;
         }
 
         private void ButtonUpdateClick(object sender, EventArgs e)

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -10,8 +10,6 @@ namespace AutoUpdaterDotNET
 {
     internal partial class UpdateForm : Form
     {
-        private bool HideReleaseNotes { get; set; }
-
         public UpdateForm()
         {
             InitializeComponent();
@@ -26,15 +24,6 @@ namespace AutoUpdaterDotNET
             labelDescription.Text =
                 string.Format(resources.GetString("labelDescription.Text", CultureInfo.CurrentCulture),
                     AutoUpdater.AppTitle, AutoUpdater.CurrentVersion, AutoUpdater.InstalledVersion);
-            if (string.IsNullOrEmpty(AutoUpdater.ChangelogURL))
-            {
-                HideReleaseNotes = true;
-                var reduceHeight = labelReleaseNotes.Height + webBrowser.Height;
-                labelReleaseNotes.Hide();
-                webBrowser.Hide();
-
-                Height -= reduceHeight;
-			}
 
             if (AutoUpdater.Mandatory && AutoUpdater.UpdateMode == Mode.Forced)
             {
@@ -84,7 +73,16 @@ namespace AutoUpdaterDotNET
 
         private void UpdateFormLoad(object sender, EventArgs e)
         {
-            if (!HideReleaseNotes)
+            if (string.IsNullOrEmpty(AutoUpdater.ChangelogURL))
+            {
+                var reduceHeight = labelReleaseNotes.Height + webBrowser.Height;
+                labelReleaseNotes.Hide();
+                webBrowser.Hide();
+                var labelSize = new Size(Width - 110, 0);
+                labelDescription.MaximumSize = labelUpdate.MaximumSize = labelSize;
+                Height -= reduceHeight;
+            }
+            else
             {
                 webBrowser.Navigate(AutoUpdater.ChangelogURL);
             }

--- a/AutoUpdater.NET/UpdateForm.resx
+++ b/AutoUpdater.NET/UpdateForm.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="webBrowser.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="webBrowser.Location" type="System.Drawing.Point, System.Drawing">
     <value>94, 120</value>
@@ -243,6 +246,9 @@
   <data name="&gt;&gt;labelReleaseNotes.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="buttonUpdate.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
   <data name="buttonUpdate.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
@@ -278,6 +284,9 @@
   </data>
   <data name="&gt;&gt;buttonUpdate.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="buttonRemindLater.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
   </data>
   <data name="buttonRemindLater.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
@@ -338,6 +347,9 @@
   </data>
   <data name="&gt;&gt;pictureBoxIcon.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="buttonSkip.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
   </data>
   <data name="buttonSkip.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>

--- a/AutoUpdater.NET/UpdateForm.resx
+++ b/AutoUpdater.NET/UpdateForm.resx
@@ -117,6 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="webBrowser.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
@@ -124,7 +125,6 @@
   <data name="webBrowser.Location" type="System.Drawing.Point, System.Drawing">
     <value>94, 120</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="webBrowser.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
   </data>
@@ -160,7 +160,7 @@
     <value>91, 14</value>
   </data>
   <data name="labelUpdate.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>560, 0</value>
+    <value>550, 0</value>
   </data>
   <data name="labelUpdate.Size" type="System.Drawing.Size, System.Drawing">
     <value>227, 19</value>

--- a/AutoUpdaterTest/FormMain.cs
+++ b/AutoUpdaterTest/FormMain.cs
@@ -99,6 +99,10 @@ namespace AutoUpdaterTest
             //AutoUpdater.Mandatory = true;
             //AutoUpdater.UpdateMode = Mode.Forced;
 
+			//Want to change update form size then uncomment below line.
+
+			//AutoUpdater.UpdateFormSize = new System.Drawing.Size(800, 600);
+
             AutoUpdater.Start("https://rbsoft.org/updates/AutoUpdaterTest.xml");
         }
 


### PR DESCRIPTION
With this change, it will be possible to specify the size of the update form in cases when the screen size does not allow displaying the update form entirely due to the low resolution.