### PR TITLE
Add support to have authorization for the changelog URL

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -121,6 +121,11 @@ namespace AutoUpdaterDotNET
         public static BasicAuthentication BasicAuthXML;
 
         /// <summary>
+        ///     Set Basic Authentication credentials to navigate to the change log URL. 
+        /// </summary>
+        public static BasicAuthentication BasicAuthChangeLog;
+
+        /// <summary>
         ///     If this is true users can see the skip button.
         /// </summary>
         public static Boolean ShowSkipButton = true;

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -91,7 +91,14 @@ namespace AutoUpdaterDotNET
             }
             else
             {
-                webBrowser.Navigate(AutoUpdater.ChangelogURL);
+                if (null != AutoUpdater.BasicAuthChangeLog)
+                {
+                    webBrowser.Navigate(AutoUpdater.ChangelogURL, "", null, $"Authorization: {AutoUpdater.BasicAuthChangeLog}");
+                }
+                else
+                {
+                   webBrowser.Navigate(AutoUpdater.ChangelogURL);
+                }
             }
 
             var labelSize = new Size(Width - 110, 0);


### PR DESCRIPTION
The XML and download URLs both already support authorization; the changelog URL does not.
This pull request addresses this shortcoming.
