### PR TITLE
Fix TryToFindFileName

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -261,16 +261,19 @@ namespace AutoUpdaterDotNET
             string fileName = String.Empty;
             if (!string.IsNullOrEmpty(contentDisposition))
             {
-                var index = contentDisposition.IndexOf(lookForFileName, StringComparison.CurrentCultureIgnoreCase);
-                if (index >= 0)
-                    fileName = contentDisposition.Substring(index + lookForFileName.Length);
-                if (fileName.StartsWith("\""))
+                foreach(var line in contentDisposition.Split(';'))
                 {
-                    var file = fileName.Substring(1, fileName.Length - 1);
-                    var i = file.IndexOf("\"", StringComparison.CurrentCultureIgnoreCase);
-                    if (i != -1)
+                    var index = line.IndexOf(lookForFileName, StringComparison.CurrentCultureIgnoreCase);
+                    if (index >= 0)
+                        fileName = line.Substring(index + lookForFileName.Length);
+                    if (fileName.StartsWith("\""))
                     {
-                        fileName = file.Substring(0, i);
+                        var file = fileName.Substring(1, fileName.Length - 1);
+                        var i = file.IndexOf("\"", StringComparison.CurrentCultureIgnoreCase);
+                        if (i != -1)
+                        {
+                            fileName = file.Substring(0, i);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Provide support for parsing contentDispostion values that are returned by AzureDevOps while maintaining backwards compatibility. 
input:`attachment; filename = SomeFile.zip; filename *= utf - 8''SomeFile.zip`
After:
`TryToFindFileName(contentDisposition,"filename=")` => `SomeFile.zip`
`TryToFindFileName(contentDisposition, "filename*=UTF-8''")`  => `SomeFile.zip`

Before: 
`TryToFindFileName(contentDisposition,"filename=")` => `PackUtility.zip; filename*=utf-8''PackUtility.zip`
`TryToFindFileName(contentDisposition, "filename*=UTF-8''")`  => `SomeFile.zip`


This bug resulted in an exception:
```
{"Illegal characters in path."}
 	mscorlib.dll!System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(string fullPath) Line 1105	C#
 	mscorlib.dll!System.Security.Permissions.FileIOPermission.QuickDemand(System.Security.Permissions.FileIOPermissionAccess access, string fullPath, bool checkForDuplicates, bool needFullPath) Line 1015	C#
 	mscorlib.dll!System.IO.File.InternalMove(string sourceFileName, string destFileName, bool checkHost) Line 1262	C#
>	AutoUpdater.NET!AutoUpdaterDotNET.DownloadUpdateDialog.WebClientOnDownloadFileCompleted(object sender, System.ComponentModel.AsyncCompletedEventArgs asyncCompletedEventArgs) Line 158	C#
 	System.dll!System.Net.WebClient.OnDownloadFileCompleted(System.ComponentModel.AsyncCompletedEventArgs e) Line 2065	C#
 	System.dll!System.Net.WebClient.DownloadFileOperationCompleted(object arg) Line 2069	C#

```