### PR TITLE
Added the possibility to set the user agent for http requests

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -124,9 +124,9 @@ namespace AutoUpdaterDotNET
         ///     Set Basic Authentication credentials to navigate to the change log URL. 
         /// </summary>
         public static BasicAuthentication BasicAuthChangeLog;
-        
+
         /// <summary>
-        ///     Set the http User Agent.
+        ///     Set the User-Agent string to be used for HTTP web requests.
         /// </summary>
         public static string HttpUserAgent;
         
@@ -422,16 +422,12 @@ namespace AutoUpdaterDotNET
                 else if(uri.Scheme.Equals(Uri.UriSchemeHttp) || uri.Scheme.Equals(Uri.UriSchemeHttps))
                 {
                     HttpWebRequest httpWebRequest = (HttpWebRequest) webRequest;
-                    httpWebRequest.UserAgent = $"{AppTitle}/{InstalledVersion}";
+
+                    httpWebRequest.UserAgent = GetUserAgent();
 
                     if (BasicAuthXML != null)
                     {
                         httpWebRequest.Headers[HttpRequestHeader.Authorization] = BasicAuthXML.ToString();
-                    }
-
-                    if (HttpUserAgent != string.Empty)
-                    {
-                        ((HttpWebRequest)webRequest).UserAgent = HttpUserAgent;
                     }
 
                     webResponse = httpWebRequest.GetResponse();
@@ -716,6 +712,11 @@ namespace AutoUpdaterDotNET
             }
 
             return (Attribute) attributes[0];
+        }
+
+        internal static string GetUserAgent()
+        {
+            return string.IsNullOrEmpty(HttpUserAgent) ? $"{AppTitle}/{InstalledVersion}" : HttpUserAgent;
         }
 
         internal static void SetTimer(DateTime remindLater)

--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -124,7 +124,12 @@ namespace AutoUpdaterDotNET
         ///     Set Basic Authentication credentials to navigate to the change log URL. 
         /// </summary>
         public static BasicAuthentication BasicAuthChangeLog;
-
+        
+        /// <summary>
+        ///     Set the http User Agent.
+        /// </summary>
+        public static string HttpUserAgent;
+        
         /// <summary>
         ///     If this is true users can see the skip button.
         /// </summary>
@@ -422,6 +427,11 @@ namespace AutoUpdaterDotNET
                     if (BasicAuthXML != null)
                     {
                         httpWebRequest.Headers[HttpRequestHeader.Authorization] = BasicAuthXML.ToString();
+                    }
+
+                    if (HttpUserAgent != string.Empty)
+                    {
+                        ((HttpWebRequest)webRequest).UserAgent = HttpUserAgent;
                     }
 
                     webResponse = httpWebRequest.GetResponse();

--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -47,9 +47,14 @@ namespace AutoUpdaterDotNET
             {
                 _webClient = new MyWebClient();
 
-                if (AutoUpdater.BasicAuthDownload != null)
+                if (uri.Scheme.Equals(Uri.UriSchemeHttp) || uri.Scheme.Equals(Uri.UriSchemeHttps))
                 {
-                    _webClient.Headers[HttpRequestHeader.Authorization] = AutoUpdater.BasicAuthDownload.ToString();
+                    if (AutoUpdater.BasicAuthDownload != null)
+                    {
+                        _webClient.Headers[HttpRequestHeader.Authorization] = AutoUpdater.BasicAuthDownload.ToString();
+                    }
+
+                    _webClient.Headers[HttpRequestHeader.UserAgent] = AutoUpdater.GetUserAgent();
                 }
             }
 


### PR DESCRIPTION
A lot of services require a valid useragent to interact with their API, including github!
So if you wanna get the json response to get your latest release from github, you must specify an user agent.
At this point I just added the possibility to set the user agent for http requests.

Related to the issue #296 