### PR TITLE
Fix: :pencil: Typo in Forced updates documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ AutoUpdater.Mandatory = true;
 
 ### Forced updates
 
-You can enable forced updates by setting Mandatory property to true and setting UpdateMode to value of "Forced" or "ForceDownload". "Forced" option will hide Remind Later, Skip and Close buttons on the standard update dialog. "ForceDownload" option will skip the standard update dialog and start downloading and updating the application without user interaction. "ForceDownload" option will also ignore value of OpenDownloadPage flag.
+You can enable forced updates by setting Mandatory property to true and setting UpdateMode to value of `Mode.Forced` or `Mode.ForcedDownload`. `Mode.Forced` option will hide Remind Later, Skip and Close buttons on the standard update dialog. `Mode.ForcedDownload` option will skip the standard update dialog and start downloading and updating the application without user interaction. `Mode.ForceDownload` option will also ignore value of OpenDownloadPage flag.
 
 ````csharp
 AutoUpdater.Mandatory = true;


### PR DESCRIPTION
As per the documentation:

https://github.com/ravibpatel/AutoUpdater.NET/blob/2c20442ed7f67e1dba8f251df6a8a0f13166a857/AutoUpdater.NET/AutoUpdater.cs#L40-L59