### PR TITLE
ZipExtractor takes a long time to detect running processes prior to upgrade

### DIFF
--- a/ZipExtractor/FormMain.cs
+++ b/ZipExtractor/FormMain.cs
@@ -51,7 +51,7 @@ namespace ZipExtractor
 
                 _backgroundWorker.DoWork += (o, eventArgs) =>
                 {
-                    foreach (var process in Process.GetProcesses())
+                    foreach (var process in Process.GetProcessesByName(Path.GetFileNameWithoutExtension(executablePath)))
                     {
                         try
                         {


### PR DESCRIPTION
Hi Ravi, 

Great work with the AutoUpdater. Many thanks for saving us a lot of time.

We ran into an issue when performing the AutoUpdater in Terminal servers which can potentially be running thousands of processes. ZipExtractor was basically looping through each process to check if the executable was the same as the executable being upgraded. This causes the dialog box to stay on "Extracting..." for up to 5-10 mins before the upgrade finally kicks in.

To fix, we suggest this one-line change which first queries all processes which share the same name as the executable. The loop then checks if it is *exactly* the same executable as the one being upgraded. Would be great if this was put in as part of your package.

Best regards,

Kheng Kiat Su