### PR TITLE
Added Support for Http Credentials

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -101,6 +101,11 @@ namespace AutoUpdaterDotNET
         public static NetworkCredential FtpCredentials;
 
         /// <summary>
+        /// Login/password/domain for FTP-request
+        /// </summary>
+        public static NetworkCredential HttpCredentials;
+
+        /// <summary>
         ///     Opens the download URL in default browser if true. Very usefull if you have portable application.
         /// </summary>
         public static bool OpenDownloadPage;
@@ -681,8 +686,14 @@ namespace AutoUpdaterDotNET
             }
             else
             {
-                basicAuthentication?.Apply(ref webClient);
-
+                if (HttpCredentials != null)
+                {
+                    webClient.Credentials = HttpCredentials;
+                }
+                else
+                {
+                    basicAuthentication?.Apply(ref webClient);
+                }
                 webClient.Headers[HttpRequestHeader.UserAgent] = HttpUserAgent;
             }
 


### PR DESCRIPTION
I was wondering how to provide Credentials for Http Requests. In form of Network Credentials.
I need this because I want to use `CredentialCache.DefaultNetworkCredentials` to get the currently logged in user.

But one can not use the BasicAuthentication Class since the UserName and Passwort are empty, because of:
The ICredentials instance returned by DefaultCredentials cannot be used to view the user name, password, or domain of the current security context.

I checked with fiddler and there really was an empty Username and an empty Passwort. 

I think it would work, if the Credentials are directly providede as an NetworkCredentials object.