### PR TITLE
Fixed race condition in SetTimer()

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -598,7 +598,7 @@ namespace AutoUpdaterDotNET
 
             _remindLaterTimer = new System.Timers.Timer
             {
-                Interval = (int) timeSpan.TotalMilliseconds,
+                Interval = Math.Max(1, timeSpan.TotalMilliseconds),
                 AutoReset = false
             };
 


### PR DESCRIPTION
This fixes the following issue:

```
ArgumentException
  Message="-3127" ist kein gültiger Wert für "Interval". "Interval" muss größer als 0 sein.
  TargetSite=Void set_Interval(Double)
  Source=System
  HResult=-2147024809
  StackTrace=
    bei System.Timers.Timer.set_Interval(Double value)
    bei AutoUpdaterDotNET.AutoUpdater.SetTimer(DateTime remindLater) in c:\projects\AutoUpdater.NET\AutoUpdater.NET\AutoUpdater.cs:Zeile 594.
    bei AutoUpdaterDotNET.AutoUpdater.StartUpdate(Object result) in c:\projects\AutoUpdater.NET\AutoUpdater.NET\AutoUpdater.cs:Zeile 435.
    bei AutoUpdaterDotNET.AutoUpdater.<>c.<Start>b__42_1(Object _, RunWorkerCompletedEventArgs args) in c:\projects\AutoUpdater.NET\AutoUpdater.NET\AutoUpdater.cs:Zeile 319.
    bei System.ComponentModel.BackgroundWorker.OnRunWorkerCompleted(RunWorkerCompletedEventArgs e)
```

This seems to be related to #451.

I could reproduce this problem with the following code (in `CheckUpdate()`):
```
var remindLaterAt = PersistenceProvider.GetRemindLater();
remindLaterAt = DateTime.Now.AddMilliseconds(1); // let's race!
if (remindLaterAt != null)
{
    int compareResult = DateTime.Compare(DateTime.Now, remindLaterAt.Value);

    if (compareResult < 0)
    {
        return remindLaterAt.Value;
    }
}
```
