### PR TITLE
Adding cookies use

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -192,6 +192,11 @@ namespace AutoUpdaterDotNET
         public static RemindLaterFormat RemindLaterTimeSpan = RemindLaterFormat.Days;
 
         /// <summary>
+        /// Set if we need to use cookies for the WebClient.
+        /// </summary>
+        public static bool UseCookies = false;
+
+        /// <summary>
         ///     A delegate type to handle how to exit the application after update is downloaded.
         /// </summary>
         public delegate void ApplicationExitEventHandler();
@@ -665,7 +670,7 @@ namespace AutoUpdaterDotNET
 
         internal static MyWebClient GetWebClient(Uri uri, IAuthentication basicAuthentication)
         {
-            MyWebClient webClient = new MyWebClient
+            MyWebClient webClient = new MyWebClient(useCookies: UseCookies)
             {
                 CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore)
             };

--- a/AutoUpdater.NET/MyWebClient.cs
+++ b/AutoUpdater.NET/MyWebClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 
 namespace AutoUpdaterDotNET
@@ -11,12 +11,54 @@ namespace AutoUpdaterDotNET
         /// </summary>
         public Uri ResponseUri;
 
+        /// <summary>
+        /// Container of cookies.
+        /// </summary>
+        public CookieContainer CookieContainer;
+
+        private bool _useCookies;
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        /// <param name="useCookies"></param>
+        public MyWebClient(bool useCookies)
+        {
+            _useCookies = useCookies;
+        }
+
         /// <inheritdoc />
         protected override WebResponse GetWebResponse(WebRequest request, IAsyncResult result)
         {
             WebResponse webResponse = base.GetWebResponse(request, result);
             ResponseUri = webResponse.ResponseUri;
+            
+            if (_useCookies)
+            {
+                string setCookieHeader = webResponse.Headers[HttpResponseHeader.SetCookie];
+
+                //do something if needed to parse out the cookie.
+                if (setCookieHeader != null)
+                {
+                    Cookie cookie = new Cookie(); //create cookie
+                    CookieContainer.SetCookies(request.RequestUri, setCookieHeader);
+                }
+            }
+
             return webResponse;
+        }
+
+        /// <inheritdoc />
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            WebRequest request = base.GetWebRequest(address);
+
+            if (_useCookies && request is HttpWebRequest)
+                (request as HttpWebRequest).CookieContainer = CookieContainer;
+
+            HttpWebRequest httpRequest = (HttpWebRequest)request;
+            httpRequest.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            return httpRequest;
         }
     }
 }


### PR DESCRIPTION
To enable the possibility of download files frome OneDrive for example, we need to enable Cookies on the WebClient.