### PR TITLE
Fixed issue with webview2 when changelog has linked files and auth is enabled

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.NET.csproj
+++ b/AutoUpdater.NET/AutoUpdater.NET.csproj
@@ -11,16 +11,16 @@
         <Company>RBSoft</Company>
         <Product>AutoUpdater.NET</Product>
         <Copyright>Copyright © 2012-2022 RBSoft</Copyright>
-        <Version>1.7.2.0</Version>
-        <AssemblyVersion>1.7.2.0</AssemblyVersion>
-        <FileVersion>1.7.2.0</FileVersion>
+        <Version>1.7.3.0</Version>
+        <AssemblyVersion>1.7.3.0</AssemblyVersion>
+        <FileVersion>1.7.3.0</FileVersion>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>AutoUpdater.NET.snk</AssemblyOriginatorKeyFile>
         <NeutralLanguage>en</NeutralLanguage>
         <PackageId>Autoupdater.NET.Official</PackageId>
         <IncludeSymbols>true</IncludeSymbols>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>1.7.2.0</PackageVersion>
+        <PackageVersion>1.7.3.0</PackageVersion>
         <Title>AutoUpdater.NET</Title>
         <Authors>rbsoft</Authors>
         <Description>AutoUpdater.NET is a class library that allows .NET developers to easily add auto update functionality to their WinForms or WPF application projects.</Description>

--- a/AutoUpdater.NET/BasicAuthentication.cs
+++ b/AutoUpdater.NET/BasicAuthentication.cs
@@ -9,9 +9,9 @@ namespace AutoUpdaterDotNET
     /// </summary>
     public class BasicAuthentication : IAuthentication
     {
-        private string Username { get; }
+        public string Username { get; }
 
-        private string Password { get; }
+        public string Password { get; }
 
         /// <summary>
         ///     Initializes credentials for Basic Authentication.

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -93,13 +93,15 @@ namespace AutoUpdaterDotNET
             webView2.BringToFront();
             if (null != AutoUpdater.BasicAuthChangeLog)
             {
-                var resourceRequest = webView2.CoreWebView2.Environment.CreateWebResourceRequest(_args.ChangelogURL, "GET", Stream.Null, $"Authorization: {AutoUpdater.BasicAuthChangeLog}");
-                webView2.CoreWebView2.NavigateWithWebResourceRequest(resourceRequest);
+                webView2.CoreWebView2.BasicAuthenticationRequested += delegate (
+                    object sender,
+                    CoreWebView2BasicAuthenticationRequestedEventArgs args)
+                    {
+                        args.Response.UserName = ((BasicAuthentication)AutoUpdater.BasicAuthChangeLog).Username;
+                        args.Response.Password = ((BasicAuthentication)AutoUpdater.BasicAuthChangeLog).Password;
+                    };
             }
-            else
-            {
-                webView2.CoreWebView2.Navigate(_args.ChangelogURL);
-            }
+            webView2.CoreWebView2.Navigate(_args.ChangelogURL);
         }
 
         private void UseLatestIE()

--- a/AutoUpdater.NET/build/Autoupdater.NET.Official.nuspec
+++ b/AutoUpdater.NET/build/Autoupdater.NET.Official.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Autoupdater.NET.Official</id>
-    <version>1.7.2.0</version>
+    <version>1.7.3.0</version>
     <title>AutoUpdater.NET</title>
     <authors>rbsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
-version: 1.7.2.{build}
+version: 1.7.3.{build}
 environment:
-  my_version: 1.7.2
+  my_version: 1.7.3
   my_secret:
     secure: vbPRaZLQYpGPr4BrZZ4p6TofpSZMud+FKtlpqjgO8aA=
 skip_branch_with_pr: true


### PR DESCRIPTION
When using Webview2, if the changelog is password protected but the file has other linked files (for example, a css file) then the request for that linked file is made without credentials which triggers an auth dialog from the browser/webview2.

The initial implementation appeared to be only using the credentials for the single first request to the changelog file and not setting the credentials for the other "sub" requests.

This change sets a delegate on the BasicAuthenticationRequested event as [per the Microsoft documentation](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/basic-authentication?tabs=csharp#tabpanel_1_csharp) that sets the user and password as provided by the user configuration.

The visibility on the Username and Password properties were changed to public in order to be able to access them directly, but feel free to refactor this and create some getters if you wish to keep them private.

Also note, that I've only tested this on my setup which has the same password for everything (xml, changelog and download) so I'm not sure if there will be any side-effects when the credentials are different for each.

Cheers