### PR TITLE
Clear cache and add user-agent on webview2 changelog request

### DIFF
--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -89,6 +89,8 @@ namespace AutoUpdaterDotNET
             webView2.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
             webView2.CoreWebView2.Settings.IsStatusBarEnabled = false;
             webView2.CoreWebView2.Settings.AreDevToolsEnabled = Debugger.IsAttached;
+            webView2.CoreWebView2.Settings.UserAgent = AutoUpdater.GetUserAgent();
+            webView2.CoreWebView2.Profile.ClearBrowsingDataAsync();
             webView2.Show();
             webView2.BringToFront();
             if (null != AutoUpdater.BasicAuthChangeLog)


### PR DESCRIPTION
PR with 2 line addition that I believe should be merged or at least considered:

- When using webview2, changelog requests can get cached by the webview2 instance profile and not load the latest changes on the update window. This can usually be handled by proper expiration header usage on the webserver side but I figure that it's a safer bet to always clear the cache before loading the changelog as that may not always be possible and is dependent on many external network factors. (alternatively, maybe add a new boolean setting for this?)

- This also makes webview2 use whatever user-agent was set for the HttpUserAgent variable when loading the changelog and not just when requesting the update XML file. (Useful for website display logic when you wish to reuse the same changelog on your website and also inside the updater webiew2. For example, hiding extra menus/content when requesting from updater)

Cheers.