### PR TITLE
Fall-back for wrongly formatted content-disposition headers

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -101,10 +101,19 @@ namespace AutoUpdaterDotNET
                     CompareChecksum(_tempFile, _args.CheckSum);
                 }
 
+                // try to parse the content disposition header if it exists
                 ContentDisposition contentDisposition = null;
-                if (!string.IsNullOrWhiteSpace(_webClient.ResponseHeaders?["Content-Disposition"]))
+                try
                 {
-                    contentDisposition = new ContentDisposition(_webClient.ResponseHeaders["Content-Disposition"]);
+                    if (!string.IsNullOrWhiteSpace(_webClient.ResponseHeaders?["Content-Disposition"]))
+                    {
+                        contentDisposition = new ContentDisposition(_webClient.ResponseHeaders["Content-Disposition"]);
+                    }
+                } 
+                catch (FormatException)
+                {
+                    // ignore content disposition header if it is wrongly formated
+                    contentDisposition = null;
                 }
 
                 var fileName = string.IsNullOrEmpty(contentDisposition?.FileName)


### PR DESCRIPTION
Some servers provided wrongly formatted content-disposition headers, e.g. Artifactory writes as Content-Disposition

attachment; filename="setup.exe"; filename*=UTF-8''"setup.exe"

where the quotations (") within the filename* parameter yield a C# Format-Exception and cause a error message to be displayed. Since AutoUpdater.NET does not rely on the Content-Disposition Header but can fall-back to the filename from the download URL, this PR catches such errors and ignores such faulty Content-Disposition headers.