### PR TITLE
Fixed firt letter to capital in DownloadUpdateDialog spanish translation

### DIFF
--- a/AutoUpdater.NET/DownloadUpdateDialog.es.resx
+++ b/AutoUpdater.NET/DownloadUpdateDialog.es.resx
@@ -127,6 +127,6 @@
     <value>Descargar Update...</value>
   </data>
     <data name="$this.Text" xml:space="preserve">
-    <value>actualización de software</value>
+    <value>Actualización de software</value>
   </data>
 </root>


### PR DESCRIPTION
For maintaining the same format with other languaje translations of the same Form, that uses capital in the first letter of the window title, my suggestion is to change the spanish translation of DownloadUpdateDialog to capital letter: "actualización de software" to "Actualización de software".