### PR TITLE
fixed issue with Process.Start() in NETCOREAPP

### DIFF
--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -177,8 +177,13 @@ internal sealed partial class UpdateForm : Form
     {
         if (AutoUpdater.OpenDownloadPage)
         {
+            
             var processStartInfo = new ProcessStartInfo(_args.DownloadURL);
-
+#if NETCOREAPP
+            // for .NET Core, UseShellExecute must be set to true, otherwise
+            // opening URLs via Process.Start() fails 
+            processStartInfo.UseShellExecute = true;
+#endif
             Process.Start(processStartInfo);
 
             DialogResult = DialogResult.OK;


### PR DESCRIPTION
in a .NET Core application, `UseShellExecute` must be set to `true` for the URL to be opened correctly in a browser