### PR TITLE
Added Timeout option in MyWebClient class for the WebRequest

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -246,6 +246,11 @@ public static class AutoUpdater
     public static Mode UpdateMode;
 
     /// <summary>
+    ///     Set the timeout in milliseconds for WebRequest of WebClient, default is 100000ms
+    /// </summary>
+    public static int Timeout = 100000;
+
+    /// <summary>
     ///     An event that developers can use to exit the application gracefully.
     /// </summary>
     public static event ApplicationExitEventHandler ApplicationExitEvent;
@@ -734,7 +739,8 @@ public static class AutoUpdater
     {
         var webClient = new MyWebClient
         {
-            CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore)
+            CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore),
+            Timeout = AutoUpdater.Timeout
         };
 
         if (Proxy != null)

--- a/AutoUpdater.NET/MyWebClient.cs
+++ b/AutoUpdater.NET/MyWebClient.cs
@@ -11,11 +11,24 @@ public class MyWebClient : WebClient
     /// </summary>
     public Uri ResponseUri;
 
+    /// <summary>
+    ///     Set Request timeout in milliseconds
+    /// </summary>
+    public int Timeout;
+
     /// <inheritdoc />
     protected override WebResponse GetWebResponse(WebRequest request, IAsyncResult result)
     {
         WebResponse webResponse = base.GetWebResponse(request, result);
         ResponseUri = webResponse.ResponseUri;
         return webResponse;
+    }
+
+    /// <inheritdoc />
+    protected override WebRequest GetWebRequest(Uri address)
+    {
+        WebRequest webRequest = base.GetWebRequest(address);
+        webRequest.Timeout = Timeout;
+        return webRequest;
     }
 }


### PR DESCRIPTION
Hi, I added a static property Timeout to the AutoUpdater class to configure the timeout in milliseconds for web requests made by WebClient, with a default value of 100,000 ms. 

The GetWebClient method now sets the Timeout of the MyWebClient instance to AutoUpdater.Timeout. The MyWebClient class also includes a new Timeout property and the GetWebRequest method has been overridden to use this value.

The reason is because by default WebRequest timeout sometimes is not enough to establish connection to the http server, as commented in this issue #489.

However, this could be a temporary solution because of #676.

We tested it under local conditions, but you are free to test it in more scenarios. Sometimes, it still shows the WebClient request error when intentionally disconnecting from the internet and reconnecting. It only waits for the timeout but does not resume the download, ~possibly due to the way WebClient works...~ Edit: It looks like our HTTP server is closing the connection with the client at the moment it loses internet connection. So, the issue is on our side. Testing it with the AutoUpdaterTest project works fine.

Closes #489

Saludos 😄 🇲🇽 

