### PR TITLE
feat: Add plugin system for changelog viewers

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -12,6 +12,7 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Serialization;
+using AutoUpdaterDotNET.ChangelogViewers;
 using AutoUpdaterDotNET.Properties;
 using Application = System.Windows.Forms.Application;
 using MessageBox = System.Windows.Forms.MessageBox;
@@ -244,7 +245,12 @@ public static class AutoUpdater
     ///     Set this to any of the available modes to change behaviour of the Mandatory flag.
     /// </summary>
     public static Mode UpdateMode;
-
+    
+    /// <summary>
+    ///     Set this to any of the available types to change the changelog viewer.
+    /// </summary>
+    public static ChangelogViewerType ChangelogViewerType = ChangelogViewerFactory.GetDefaultViewerType();
+    
     /// <summary>
     ///     An event that developers can use to exit the application gracefully.
     /// </summary>

--- a/AutoUpdater.NET/ChangelogViewers/ChangelogViewerFactory.cs
+++ b/AutoUpdater.NET/ChangelogViewers/ChangelogViewerFactory.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace AutoUpdaterDotNET.ChangelogViewers;
+
+public static class ChangelogViewerFactory
+{
+    public static IChangelogViewer Create(ChangelogViewerType type)
+    {
+        return type switch
+        {
+            ChangelogViewerType.RichTextBox => new RichTextBoxViewer(),
+            ChangelogViewerType.WebBrowser => new WebBrowserViewer(),
+            ChangelogViewerType.WebView2 when WebView2Viewer.IsAvailable() => new WebView2Viewer(),
+            ChangelogViewerType.WebView2 => throw new InvalidOperationException("WebView2 runtime is not available"),
+            _ => throw new ArgumentException($"Unknown viewer type: {type}")
+        };
+    }
+
+    public static ChangelogViewerType GetDefaultViewerType()
+    {
+        if (WebView2Viewer.IsAvailable())
+            return ChangelogViewerType.WebView2;
+            
+        return ChangelogViewerType.WebBrowser;
+    }
+}

--- a/AutoUpdater.NET/ChangelogViewers/ChangelogViewerType.cs
+++ b/AutoUpdater.NET/ChangelogViewers/ChangelogViewerType.cs
@@ -1,0 +1,8 @@
+namespace AutoUpdaterDotNET.ChangelogViewers;
+
+public enum ChangelogViewerType
+{
+    RichTextBox,
+    WebBrowser,
+    WebView2
+}

--- a/AutoUpdater.NET/ChangelogViewers/IChangelogViewer.cs
+++ b/AutoUpdater.NET/ChangelogViewers/IChangelogViewer.cs
@@ -1,0 +1,12 @@
+using System.Windows.Forms;
+
+namespace AutoUpdaterDotNET.ChangelogViewers;
+
+public interface IChangelogViewer
+{
+    Control Control { get; }
+    bool SupportsUrl { get; }
+    void LoadContent(string content);
+    void LoadUrl(string url);
+    void Cleanup();
+}

--- a/AutoUpdater.NET/ChangelogViewers/RichTextBoxViewer.cs
+++ b/AutoUpdater.NET/ChangelogViewers/RichTextBoxViewer.cs
@@ -1,0 +1,31 @@
+using System.Windows.Forms;
+
+namespace AutoUpdaterDotNET.ChangelogViewers;
+
+public class RichTextBoxViewer : IChangelogViewer
+{
+    private readonly RichTextBox _richTextBox = new()
+    {
+        ReadOnly = true,
+        Dock = DockStyle.Fill,
+        BackColor = System.Drawing.SystemColors.Control,
+        BorderStyle = BorderStyle.Fixed3D
+    };
+    public Control Control => _richTextBox;
+    public bool SupportsUrl => false;
+
+    public void LoadContent(string content)
+    {
+        _richTextBox.Text = content;
+    }
+
+    public void LoadUrl(string url)
+    {
+        throw new System.NotSupportedException("RichTextBox does not support loading from URL");
+    }
+
+    public void Cleanup()
+    {
+        _richTextBox.Dispose();
+    }
+}

--- a/AutoUpdater.NET/ChangelogViewers/WebBrowserViewer.cs
+++ b/AutoUpdater.NET/ChangelogViewers/WebBrowserViewer.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using System.Diagnostics;
+using System.Windows.Forms;
+using Microsoft.Win32;
+
+namespace AutoUpdaterDotNET.ChangelogViewers;
+
+public class WebBrowserViewer : IChangelogViewer
+{
+    private const string EmulationKey = @"SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION";
+    private readonly int _emulationValue;
+    private readonly string _executableName;
+    private readonly WebBrowser _webBrowser;
+    public Control Control => _webBrowser;
+    public bool SupportsUrl => true;
+
+    public WebBrowserViewer()
+    {
+        _webBrowser = new WebBrowser
+        {
+            Dock = DockStyle.Fill,
+            ScriptErrorsSuppressed = true,
+            AllowWebBrowserDrop = false,
+            WebBrowserShortcutsEnabled = false,
+            IsWebBrowserContextMenuEnabled = false
+        };
+
+        _executableName = Path.GetFileName(
+            Process.GetCurrentProcess().MainModule?.FileName
+            ?? System.Reflection.Assembly.GetEntryAssembly()?.Location
+            ?? Application.ExecutablePath);
+
+        _emulationValue = _webBrowser.Version.Major switch
+        {
+            11 => 11001,
+            10 => 10001,
+            9 => 9999,
+            8 => 8888,
+            7 => 7000,
+            _ => 0
+        };
+
+        SetupEmulation();
+    }
+
+    public void LoadContent(string content) => _webBrowser.DocumentText = content;
+
+    public void LoadUrl(string url)
+    {
+        if (AutoUpdater.BasicAuthChangeLog != null)
+            _webBrowser.Navigate(url, "", null, $"Authorization: {AutoUpdater.BasicAuthChangeLog}");
+        else
+            _webBrowser.Navigate(url);
+    }
+    private void SetupEmulation()
+    {
+        if (_emulationValue == 0)
+            return;
+
+        try
+        {
+            using var registryKey = Registry.CurrentUser.OpenSubKey(EmulationKey, true);
+            registryKey?.SetValue(_executableName, _emulationValue, RegistryValueKind.DWord);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+    private void RemoveEmulation()
+    {
+        if (_emulationValue == 0)
+            return;
+
+        try
+        {
+            using var registryKey = Registry.CurrentUser.OpenSubKey(EmulationKey, true);
+            registryKey?.DeleteValue(_executableName, false);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    public void Cleanup()
+    {
+        _webBrowser.Dispose();
+        RemoveEmulation();
+    }
+}

--- a/AutoUpdater.NET/ChangelogViewers/WebView2Viewer.cs
+++ b/AutoUpdater.NET/ChangelogViewers/WebView2Viewer.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+using System.Threading.Tasks;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace AutoUpdaterDotNET.ChangelogViewers;
+
+public class WebView2Viewer : IChangelogViewer
+{
+    private bool _isInitialized;
+    private readonly WebView2 _webView = new()
+    {
+        Dock = DockStyle.Fill,
+        AllowExternalDrop = false
+    };
+    public Control Control => _webView;
+    public bool SupportsUrl => true;
+
+    private async Task EnsureInitialized()
+    {
+        if (_isInitialized) return;
+
+        try
+        {
+            await _webView.EnsureCoreWebView2Async(await CoreWebView2Environment.CreateAsync(null, Path.GetTempPath()));
+            _isInitialized = true;
+        }
+        catch (Exception)
+        {
+            throw new InvalidOperationException("WebView2 runtime is not available");
+        }
+    }
+
+    public async void LoadContent(string content)
+    {
+        await EnsureInitialized();
+        _webView.CoreWebView2.SetVirtualHostNameToFolderMapping("local.files", Path.GetTempPath(), CoreWebView2HostResourceAccessKind.Allow);
+            
+        // Write content to a temporary HTML file
+        var tempFile = Path.Combine(Path.GetTempPath(), "changelog.html");
+        File.WriteAllText(tempFile, content);
+            
+        // Navigate to the local file
+        _webView.CoreWebView2.Navigate("https://local.files/changelog.html");
+    }
+
+    public async void LoadUrl(string url)
+    {
+        await EnsureInitialized();
+
+        if (AutoUpdater.BasicAuthChangeLog != null)
+        {
+            _webView.CoreWebView2.BasicAuthenticationRequested += delegate (object _, CoreWebView2BasicAuthenticationRequestedEventArgs args)
+            {
+                args.Response.UserName = ((BasicAuthentication)AutoUpdater.BasicAuthChangeLog).Username;
+                args.Response.Password = ((BasicAuthentication)AutoUpdater.BasicAuthChangeLog).Password;
+            };
+        }
+
+        _webView.CoreWebView2.Navigate(url);
+    }
+
+    public void Cleanup()
+    {
+        if (File.Exists(Path.Combine(Path.GetTempPath(), "changelog.html")))
+        {
+            try
+            {
+                File.Delete(Path.Combine(Path.GetTempPath(), "changelog.html"));
+            }
+            catch
+            {
+                // Ignore deletion errors
+            }
+        }
+        _webView.Dispose();
+    }
+
+    public static bool IsAvailable()
+    {
+        try
+        {
+            var availableBrowserVersion = CoreWebView2Environment.GetAvailableBrowserVersionString(null);
+            const string requiredMinBrowserVersion = "86.0.616.0";
+            return !string.IsNullOrEmpty(availableBrowserVersion) &&
+                   CoreWebView2Environment.CompareBrowserVersions(availableBrowserVersion,
+                       requiredMinBrowserVersion) >= 0;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/AutoUpdater.NET/UpdateForm.Designer.cs
+++ b/AutoUpdater.NET/UpdateForm.Designer.cs
@@ -9,19 +9,6 @@ namespace AutoUpdaterDotNET
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>
@@ -31,7 +18,6 @@ namespace AutoUpdaterDotNET
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UpdateForm));
-            this.webBrowser = new System.Windows.Forms.WebBrowser();
             this.labelUpdate = new System.Windows.Forms.Label();
             this.labelDescription = new System.Windows.Forms.Label();
             this.labelReleaseNotes = new System.Windows.Forms.Label();
@@ -39,16 +25,9 @@ namespace AutoUpdaterDotNET
             this.buttonRemindLater = new System.Windows.Forms.Button();
             this.pictureBoxIcon = new System.Windows.Forms.PictureBox();
             this.buttonSkip = new System.Windows.Forms.Button();
-            this.webView2 = new Microsoft.Web.WebView2.WinForms.WebView2();
+            this.pnlChangelog = new System.Windows.Forms.Panel();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxIcon)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.webView2)).BeginInit();
             this.SuspendLayout();
-            // 
-            // webBrowser
-            // 
-            resources.ApplyResources(this.webBrowser, "webBrowser");
-            this.webBrowser.Name = "webBrowser";
-            this.webBrowser.ScriptErrorsSuppressed = true;
             // 
             // labelUpdate
             // 
@@ -97,14 +76,10 @@ namespace AutoUpdaterDotNET
             this.buttonSkip.UseVisualStyleBackColor = true;
             this.buttonSkip.Click += new System.EventHandler(this.ButtonSkipClick);
             // 
-            // webView2
+            // pnlChangelog
             // 
-            this.webView2.AllowExternalDrop = true;
-            this.webView2.CreationProperties = null;
-            this.webView2.DefaultBackgroundColor = System.Drawing.Color.White;
-            resources.ApplyResources(this.webView2, "webView2");
-            this.webView2.Name = "webView2";
-            this.webView2.ZoomFactor = 1D;
+            resources.ApplyResources(this.pnlChangelog, "pnlChangelog");
+            this.pnlChangelog.Name = "pnlChangelog";
             // 
             // UpdateForm
             // 
@@ -118,8 +93,7 @@ namespace AutoUpdaterDotNET
             this.Controls.Add(this.buttonUpdate);
             this.Controls.Add(this.buttonSkip);
             this.Controls.Add(this.buttonRemindLater);
-            this.Controls.Add(this.webView2);
-            this.Controls.Add(this.webBrowser);
+            this.Controls.Add(this.pnlChangelog);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -128,7 +102,6 @@ namespace AutoUpdaterDotNET
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.UpdateForm_FormClosed);
             this.Load += new System.EventHandler(this.UpdateFormLoad);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxIcon)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.webView2)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -139,11 +112,10 @@ namespace AutoUpdaterDotNET
         private System.Windows.Forms.Button buttonRemindLater;
         private System.Windows.Forms.Button buttonUpdate;
         private System.Windows.Forms.Button buttonSkip;
-        private System.Windows.Forms.WebBrowser webBrowser;
         private System.Windows.Forms.Label labelUpdate;
         private System.Windows.Forms.Label labelDescription;
         private System.Windows.Forms.Label labelReleaseNotes;
         private System.Windows.Forms.PictureBox pictureBoxIcon;
-        private Microsoft.Web.WebView2.WinForms.WebView2 webView2;
+        private System.Windows.Forms.Panel pnlChangelog;
     }
 }

--- a/AutoUpdater.NET/UpdateForm.cs
+++ b/AutoUpdater.NET/UpdateForm.cs
@@ -3,23 +3,21 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
-using System.IO;
 using System.Windows.Forms;
-using Microsoft.Web.WebView2.Core;
-using Microsoft.Win32;
-using static System.Reflection.Assembly;
+using AutoUpdaterDotNET.ChangelogViewers;
 
 namespace AutoUpdaterDotNET;
 
 internal sealed partial class UpdateForm : Form
 {
     private readonly UpdateInfoEventArgs _args;
+    private IChangelogViewer _changelogViewer;
 
     public UpdateForm(UpdateInfoEventArgs args)
     {
         _args = args;
         InitializeComponent();
-        InitializeBrowserControl();
+        InitializeChangelogViewer();
         TopMost = AutoUpdater.TopMost;
 
         if (AutoUpdater.Icon != null)
@@ -45,131 +43,41 @@ internal sealed partial class UpdateForm : Form
         }
     }
 
-    private async void InitializeBrowserControl()
+    private void InitializeChangelogViewer()
     {
-        if (string.IsNullOrEmpty(_args.ChangelogURL))
+        if (string.IsNullOrEmpty(_args.ChangelogURL) && string.IsNullOrEmpty(_args.ChangelogText))
         {
-            int reduceHeight = labelReleaseNotes.Height + webBrowser.Height;
+            var reduceHeight = labelReleaseNotes.Height + pnlChangelog.Height;
             labelReleaseNotes.Hide();
-            webBrowser.Hide();
-            webView2.Hide();
             Height -= reduceHeight;
+            return;
+        }
+
+        // Create and configure the new viewer
+        _changelogViewer = ChangelogViewerFactory.Create(AutoUpdater.ChangelogViewerType);
+        var viewerControl = _changelogViewer.Control;
+        viewerControl.Dock = DockStyle.Fill;
+        pnlChangelog.Controls.Add(viewerControl);
+
+        if (!string.IsNullOrEmpty(_args.ChangelogText))
+        {
+            _changelogViewer.LoadContent(_args.ChangelogText);
+        }
+        else if (_changelogViewer.SupportsUrl && !string.IsNullOrEmpty(_args.ChangelogURL))
+        {
+            _changelogViewer.LoadUrl(_args.ChangelogURL);
         }
         else
         {
-            var webView2RuntimeFound = false;
-            try
-            {
-                string availableBrowserVersion = CoreWebView2Environment.GetAvailableBrowserVersionString(null);
-                var requiredMinBrowserVersion = "86.0.616.0";
-                if (!string.IsNullOrEmpty(availableBrowserVersion)
-                    && CoreWebView2Environment.CompareBrowserVersions(availableBrowserVersion,
-                        requiredMinBrowserVersion) >= 0)
-                {
-                    webView2RuntimeFound = true;
-                }
-            }
-            catch (Exception)
-            {
-                // ignored
-            }
-
-            if (webView2RuntimeFound)
-            {
-                webBrowser.Hide();
-                webView2.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
-                await webView2.EnsureCoreWebView2Async(
-                    await CoreWebView2Environment.CreateAsync(null, Path.GetTempPath()));
-            }
-            else
-            {
-                UseLatestIE();
-                if (null != AutoUpdater.BasicAuthChangeLog)
-                {
-                    webBrowser.Navigate(_args.ChangelogURL, "", null,
-                        $"Authorization: {AutoUpdater.BasicAuthChangeLog}");
-                }
-                else
-                {
-                    webBrowser.Navigate(_args.ChangelogURL);
-                }
-            }
-        }
-    }
-
-    private void WebView_CoreWebView2InitializationCompleted(object sender,
-        CoreWebView2InitializationCompletedEventArgs e)
-    {
-        if (!e.IsSuccess)
-        {
-            if (AutoUpdater.ReportErrors)
-            {
-                MessageBox.Show(this, e.InitializationException.Message, e.InitializationException.GetType().ToString(),
-                    MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            return;
-        }
-
-        webView2.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
-        webView2.CoreWebView2.Settings.IsStatusBarEnabled = false;
-        webView2.CoreWebView2.Settings.AreDevToolsEnabled = Debugger.IsAttached;
-        webView2.CoreWebView2.Settings.UserAgent = AutoUpdater.GetUserAgent();
-        webView2.CoreWebView2.Profile.ClearBrowsingDataAsync();
-        webView2.Show();
-        webView2.BringToFront();
-        if (null != AutoUpdater.BasicAuthChangeLog)
-        {
-            webView2.CoreWebView2.BasicAuthenticationRequested += delegate(
-                object _,
-                CoreWebView2BasicAuthenticationRequestedEventArgs args)
-            {
-                args.Response.UserName = ((BasicAuthentication)AutoUpdater.BasicAuthChangeLog).Username;
-                args.Response.Password = ((BasicAuthentication)AutoUpdater.BasicAuthChangeLog).Password;
-            };
-        }
-
-        webView2.CoreWebView2.Navigate(_args.ChangelogURL);
-    }
-
-    private void UseLatestIE()
-    {
-        int ieValue = webBrowser.Version.Major switch
-        {
-            11 => 11001,
-            10 => 10001,
-            9 => 9999,
-            8 => 8888,
-            7 => 7000,
-            _ => 0
-        };
-
-        if (ieValue == 0)
-        {
-            return;
-        }
-
-        try
-        {
-            using RegistryKey registryKey =
-                Registry.CurrentUser.OpenSubKey(
-                    @"SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
-                    true);
-            registryKey?.SetValue(
-                Path.GetFileName(Process.GetCurrentProcess().MainModule?.FileName ??
-                                 GetEntryAssembly()?.Location ?? Application.ExecutablePath),
-                ieValue,
-                RegistryValueKind.DWord);
-        }
-        catch (Exception)
-        {
-            // ignored
+            labelReleaseNotes.Hide();
+            viewerControl.Hide();
+            Height -= (labelReleaseNotes.Height + viewerControl.Height);
         }
     }
 
     private void UpdateFormLoad(object sender, EventArgs e)
     {
-        var labelSize = new Size(webBrowser.Width, 0);
+        var labelSize = new Size(pnlChangelog.Width, 0);
         labelDescription.MaximumSize = labelUpdate.MaximumSize = labelSize;
     }
 
@@ -250,5 +158,15 @@ internal sealed partial class UpdateForm : Form
         {
             AutoUpdater.Exit();
         }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _changelogViewer?.Cleanup();
+            components?.Dispose();
+        }
+        base.Dispose(disposing);
     }
 }

--- a/AutoUpdater.NET/UpdateForm.resx
+++ b/AutoUpdater.NET/UpdateForm.resx
@@ -125,37 +125,37 @@
     </resheader>
     <assembly alias="System.Windows.Forms"
               name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
-    <data name="webBrowser.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <data name="pnlChangelog.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
         <value>Top, Bottom, Left, Right</value>
     </data>
     <assembly alias="System.Drawing"
               name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-    <data name="webBrowser.Location" type="System.Drawing.Point, System.Drawing">
+    <data name="pnlChangelog.Location" type="System.Drawing.Point, System.Drawing">
         <value>94, 120</value>
     </data>
-    <data name="webBrowser.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <data name="pnlChangelog.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
         <value>2, 2, 2, 2</value>
     </data>
-    <data name="webBrowser.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <data name="pnlChangelog.MinimumSize" type="System.Drawing.Size, System.Drawing">
         <value>23, 23</value>
     </data>
-    <data name="webBrowser.Size" type="System.Drawing.Size, System.Drawing">
+    <data name="pnlChangelog.Size" type="System.Drawing.Size, System.Drawing">
         <value>538, 432</value>
     </data>
     <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
-    <data name="webBrowser.TabIndex" type="System.Int32, mscorlib">
+    <data name="pnlChangelog.TabIndex" type="System.Int32, mscorlib">
         <value>4</value>
     </data>
-    <data name="&gt;&gt;webBrowser.Name" xml:space="preserve">
-    <value>webBrowser</value>
+    <data name="&gt;&gt;pnlChangelog.Name" xml:space="preserve">
+    <value>pnlChangelog</value>
   </data>
-    <data name="&gt;&gt;webBrowser.Type" xml:space="preserve">
-    <value>System.Windows.Forms.WebBrowser, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <data name="&gt;&gt;pnlChangelog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-    <data name="&gt;&gt;webBrowser.Parent" xml:space="preserve">
+    <data name="&gt;&gt;pnlChangelog.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-    <data name="&gt;&gt;webBrowser.ZOrder" xml:space="preserve">
+    <data name="&gt;&gt;pnlChangelog.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
     <data name="labelUpdate.AutoSize" type="System.Boolean, mscorlib">
@@ -395,39 +395,6 @@
   </data>
     <data name="&gt;&gt;buttonSkip.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-    <data name="webView2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-        <value>Top, Bottom, Left, Right</value>
-    </data>
-    <data name="webView2.Location" type="System.Drawing.Point, System.Drawing">
-        <value>94, 120</value>
-    </data>
-    <data name="webView2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-        <value>2, 2, 2, 2</value>
-    </data>
-    <data name="webView2.MinimumSize" type="System.Drawing.Size, System.Drawing">
-        <value>23, 23</value>
-    </data>
-    <data name="webView2.Size" type="System.Drawing.Size, System.Drawing">
-        <value>538, 432</value>
-    </data>
-    <data name="webView2.TabIndex" type="System.Int32, mscorlib">
-        <value>3</value>
-    </data>
-    <data name="webView2.Visible" type="System.Boolean, mscorlib">
-        <value>False</value>
-    </data>
-    <data name="&gt;&gt;webView2.Name" xml:space="preserve">
-    <value>webView2</value>
-  </data>
-    <data name="&gt;&gt;webView2.Type" xml:space="preserve">
-    <value>Microsoft.Web.WebView2.WinForms.WebView2, Microsoft.Web.WebView2.WinForms, Version=1.0.1210.39, Culture=neutral, PublicKeyToken=2a8ab48044d2601e</value>
-  </data>
-    <data name="&gt;&gt;webView2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-    <data name="&gt;&gt;webView2.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
     <metadata name="$this.Localizable"
               type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/AutoUpdater.NET/UpdateInfoEventArgs.cs
+++ b/AutoUpdater.NET/UpdateInfoEventArgs.cs
@@ -50,6 +50,12 @@ public class UpdateInfoEventArgs : EventArgs
     }
 
     /// <summary>
+    ///     Returns text specifying changes in the new update.
+    /// </summary>
+    [XmlElement("changelogText")]
+    public string ChangelogText { get; set; }
+
+    /// <summary>
     ///     Returns newest version of the application available to download.
     /// </summary>
     [XmlElement("version")]

--- a/AutoUpdaterTest/MainWindow.xaml.cs
+++ b/AutoUpdaterTest/MainWindow.xaml.cs
@@ -25,33 +25,6 @@ public partial class MainWindow : Window
 
     private void ButtonCheckForUpdate_Click(object sender, RoutedEventArgs e)
     {
-        // Uncomment following lines to handle parsing logic of custom AppCast file.
-        // AutoUpdater.ParseUpdateInfoEvent += args =>
-        // {
-        //     dynamic? json = JsonConvert.DeserializeObject(args.RemoteData);
-        //     if (json != null)
-        //     {
-        //         args.UpdateInfo = new UpdateInfoEventArgs
-        //         {
-        //             CurrentVersion = json.version,
-        //             ChangelogURL = json.changelog,
-        //             DownloadURL = json.url,
-        //             Mandatory = new Mandatory
-        //             {
-        //                 Value = json.mandatory.value,
-        //                 UpdateMode = json.mandatory.mode,
-        //                 MinimumVersion = json.mandatory.minVersion
-        //             },
-        //             CheckSum = new CheckSum
-        //             {
-        //                 Value = json.checksum.value,
-        //                 HashingAlgorithm = json.checksum.hashingAlgorithm
-        //             }
-        //         };
-        //     }
-        // };
-        // AutoUpdater.Start("https://rbsoft.org/updates/AutoUpdaterTest.json");
-
         // Uncomment following line to run update process without admin privileges.
         // AutoUpdater.RunUpdateAsAdmin = false;
 
@@ -199,6 +172,45 @@ public partial class MainWindow : Window
 
         // Uncomment following line to change the Icon shown on the updater dialog.
         AutoUpdater.Icon = Resource.Icon;
+
+        // Uncomment following line to change the Changelog viewer type.
+        //AutoUpdater.ChangelogViewerType = ChangelogViewerType.RichTextBox;
+
+        // Uncomment following lines to handle parsing logic of custom AppCast file.
+        //AutoUpdater.HttpUserAgent = "AutoUpdaterTest";
+        //AutoUpdater.ParseUpdateInfoEvent += p =>
+        //{
+        //    var json = JsonConvert.DeserializeObject<dynamic>(p.RemoteData);
+        //    if (json == null) return;
+        //    p.UpdateInfo = new UpdateInfoEventArgs();
+        //    p.UpdateInfo.CurrentVersion = json.tag_name.Value.TrimStart('v');
+        //    p.UpdateInfo.ChangelogText = json.body;
+        //    if (AutoUpdater.ChangelogViewerType is ChangelogViewerType.WebBrowser or ChangelogViewerType.WebView2)
+        //    {
+        //        p.UpdateInfo.ChangelogText = json.body.Value.Replace("\r\n", "<br/>").Replace("\n", "<br/>");
+        //        p.UpdateInfo.ChangelogText = $"<html><body style=\"background-color:#f5f2f2;font-size:10pt;\">{p.UpdateInfo.ChangelogText}</body></html>";
+        //    }
+        //    //e.UpdateInfo.ChangelogURL = json.html_url;
+
+        //    foreach (var asset in json.assets)
+        //    {
+        //        // Get the matched runtime & architecture asset
+        //        //var split = asset.name.Value.Split('_');
+        //        //if (split.Length < 4)
+        //        //    continue;
+
+        //        //var arch = split[2].Split('.')[0];
+        //        //var runtime = split[3].Replace(".zip", "");
+
+        //        //if ("NetFW4.8.1" != runtime || arch != "x64")
+        //        //    continue;
+
+        //        var matchedAsset = asset.browser_download_url;
+        //        p.UpdateInfo.DownloadURL = matchedAsset;
+        //        break;
+        //    }
+        //};
+        //AutoUpdater.Start("https://api.github.com/repos/ravibpatel/AutoUpdater.NET/releases/latest");
 
         AutoUpdater.Start("https://rbsoft.org/updates/AutoUpdaterTest.xml");
     }


### PR DESCRIPTION
# Add Plugin System for Changelog Viewers

## Overview
This PR introduces a flexible plugin system for displaying changelog content in the update form. It replaces the current hardcoded WebView2/WebBrowser implementation with a modular system that supports multiple viewer types and can be extended with custom implementations.

This change lays the groundwork for **a future package split**, where we can separate the core functionality from specific viewer implementations, allowing users to include only the viewers they need.

## Features
- **Multiple Viewer Options**:
  - RichTextBox: Simple text display without HTML rendering
  - WebBrowser: Legacy IE-based browser (fallback option)
  - WebView2: Modern Edge WebView2 for full HTML/CSS support
  
- **Content Loading Options**:
  - Load from URL (WebBrowser and WebView2)
  - Load direct content (all viewers)
  
- **User Configuration**:
  - Set preferred viewer via `AutoUpdater.ChangelogViewerType`
  - Automatic fallback if the preferred viewer is unavailable
  
- **Extensibility**:
  - Implement `IChangelogViewer` interface for custom viewers
  - Factory pattern for viewer instantiation

## Code Changes
- Added new `ChangelogViewers` namespace
- Introduced `IChangelogViewer` interface
- Implemented three viewer types (RichTextBox, WebBrowser, WebView2)
- Modified UpdateForm to use the plugin system
- Added viewer type configuration to AutoUpdater class

## Example Usage
```csharp
// Set preferred viewer
AutoUpdater.ChangelogViewerType = ChangelogViewerType.RichTextBox;
AutoUpdater.ParseUpdateInfoEvent += p =>
{
   var json = JsonConvert.DeserializeObject<dynamic>(p.RemoteData);
   if (json == null) return;
   p.UpdateInfo = new UpdateInfoEventArgs();
   p.UpdateInfo.CurrentVersion = json.tag_name.Value.TrimStart('v');
   p.UpdateInfo.ChangelogText = json.body;
   if (AutoUpdater.ChangelogViewerType is ChangelogViewerType.WebBrowser or ChangelogViewerType.WebView2)
   {
       p.UpdateInfo.ChangelogText = json.body.Value.Replace("\r\n", "<br/>").Replace("\n", "<br/>");
       p.UpdateInfo.ChangelogText = $"<html><body style=\"background-color:#f5f2f2;font-size:10pt;\">{p.UpdateInfo.ChangelogText}</body></html>";
   }
   //e.UpdateInfo.ChangelogURL = json.html_url;
   //...
}
```

## Testing
- Tested with all viewer types
- Verified fallback behavior when WebView2 is unavailable
- Tested content loading from both URL and direct text
- Verified cleanup of resources

## Breaking Changes
None. The default behavior remains the same (WebView2 with fallback to WebBrowser).

## Future Improvements
- **Package Modularization**:
  - Split into core package (AutoUpdater.NET.Core) containing:
    - Essential update logic
    - Built-in viewers (RichTextBox, WebBrowser) using native Windows Forms controls
  - Optional package for WebView2 support:
    - AutoUpdater.NET.WebView2 (~2MB): Modern web rendering with Edge WebView2
  - Benefits:
    - Reduced dependencies for basic usage
    - Smaller package size when WebView2 isn't needed
    - More flexibility in choosing viewers
- Add support for markdown rendering
- Add configurable styling options


#470 #496 #73 #692 