### PR TITLE
Add Silent Mode option to AutoUpdater

### DIFF
--- a/AutoUpdater.NET/AutoUpdater.cs
+++ b/AutoUpdater.NET/AutoUpdater.cs
@@ -226,6 +226,11 @@ public static class AutoUpdater
     public static bool ShowSkipButton = true;
 
     /// <summary>
+    ///     Set this to true if you want to hide the download dialog (silent mode).
+    /// </summary>
+    public static bool Silent = false;
+
+    /// <summary>
     ///     Set this to true if you want to run update check synchronously.
     /// </summary>
     public static bool Synchronous = false;

--- a/AutoUpdater.NET/DownloadUpdateDialog.cs
+++ b/AutoUpdater.NET/DownloadUpdateDialog.cs
@@ -40,6 +40,14 @@ internal partial class DownloadUpdateDialog : Form
         {
             ControlBox = false;
         }
+
+        // Silent mode: hide the dialog
+        if (AutoUpdater.Silent)
+        {
+            WindowState = FormWindowState.Minimized;
+            ShowInTaskbar = false;
+            Visible = false;
+        }
     }
 
     private void DownloadUpdateDialogLoad(object sender, EventArgs e)


### PR DESCRIPTION
Introduces a 'Silent' property to AutoUpdater for hiding the download dialog. When enabled, the DownloadUpdateDialog is minimized, hidden from the taskbar, and not visible, allowing updates to proceed without user interaction.

Now you can enable Silent Mode with `AutoUpdater.Silent = true;`